### PR TITLE
Fix Python executable path in tests

### DIFF
--- a/netsec3.v3/test_protocol.py
+++ b/netsec3.v3/test_protocol.py
@@ -41,7 +41,7 @@ def recv_payload(sock, sk):
 class ChatProtocolTest(unittest.TestCase):
     def setUp(self):
         self.server = subprocess.Popen([
-            "/usr/bin/python3",
+            sys.executable,
             os.path.join("netsec3.v3", "chat_server.py"),
             str(SERVER_PORT),
         ])


### PR DESCRIPTION
## Summary
- use `sys.executable` when launching the chat server in `test_protocol`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844232f99908332bb447ea97a59aa48