### PR TITLE
Fix username validation consistency

### DIFF
--- a/netsec3.v3/chat_client.py
+++ b/netsec3.v3/chat_client.py
@@ -67,16 +67,27 @@ command_completer = WordCompleter(
     ignore_case=True,
 )
 
+USERNAME_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9_]{2,15}$")
+
+
+def is_non_empty(text: str) -> bool:
+    """Return True if the given text contains non-whitespace characters."""
+    return len(text.strip()) > 0
+
+
+def is_valid_username(text: str) -> bool:
+    """Check that the text matches the allowed username format."""
+    return bool(USERNAME_PATTERN.fullmatch(text.strip()))
+
+
 non_empty_validator = Validator.from_callable(
-    lambda t: len(t.strip()) > 0,
+    is_non_empty,
     error_message="Input required",
     move_cursor_to_end=True,
 )
 
-# Username must be 3-16 characters of letters, numbers or underscore
-username_re = re.compile(r"^[A-Za-z][A-Za-z0-9_]{2,15}$")
 username_validator = Validator.from_callable(
-    lambda t: bool(username_re.match(t.strip())),
+    is_valid_username,
     error_message="Username must start with a letter and contain only letters, numbers or '_' (3-16 chars)",
     move_cursor_to_end=True,
 )

--- a/netsec3.v3/chat_client.py
+++ b/netsec3.v3/chat_client.py
@@ -53,11 +53,14 @@ session = PromptSession()
 
 def prompt_username(message: str) -> str:
     """Prompt user for a username with format validation."""
-    return session.prompt(
+    uname = session.prompt(
         message,
         validator=username_validator,
         is_password=False,
     ).strip()
+    # Clear validator so it does not persist for subsequent prompts
+    session.default_buffer.validator = None
+    return uname
 
 command_completer = WordCompleter(
     ["signup", "signin", "message", "broadcast", "greet", "help", "logs", "exit"],

--- a/netsec3.v3/chat_client.py
+++ b/netsec3.v3/chat_client.py
@@ -309,6 +309,7 @@ def client_main_loop(sock, server_address):
                 custom_prompt,
                 completer=command_completer,
                 is_password=False,
+                validator=None,
             ).strip()
             if not action_input:
                 print_command_list()
@@ -324,6 +325,7 @@ def client_main_loop(sock, server_address):
                 pword = session.prompt(
                     "Enter password for signup: ",
                     is_password=True,
+                    validator=None,
                 ).strip()
                 if not uname or not pword:
                     console.print("<System> Username/password cannot be empty.", style="error")
@@ -344,6 +346,7 @@ def client_main_loop(sock, server_address):
                 pword = session.prompt(
                     "Enter password for signin: ",
                     is_password=True,
+                    validator=None,
                 ).strip()
                 if not uname or not pword:
                     console.print("<System> Username/password cannot be empty.", style="error")

--- a/netsec3.v3/chat_client.py
+++ b/netsec3.v3/chat_client.py
@@ -50,6 +50,15 @@ logging.basicConfig(
 custom_prompt = os.environ.get("CHAT_PROMPT", "] ")
 session = PromptSession()
 
+
+def prompt_username(message: str) -> str:
+    """Prompt user for a username with format validation."""
+    return session.prompt(
+        message,
+        validator=username_validator,
+        is_password=False,
+    ).strip()
+
 command_completer = WordCompleter(
     ["signup", "signin", "message", "broadcast", "greet", "help", "logs", "exit"],
     ignore_case=True,
@@ -311,11 +320,7 @@ def client_main_loop(sock, server_address):
                 continue
 
             if action_cmd == "signup":
-                uname = session.prompt(
-                    "Enter username for signup: ",
-                    validator=username_validator,
-                    is_password=False,
-                ).strip()
+                uname = prompt_username("Enter username for signup: ")
                 pword = session.prompt(
                     "Enter password for signup: ",
                     is_password=True,
@@ -335,11 +340,7 @@ def client_main_loop(sock, server_address):
                 print_command_list()
 
             elif action_cmd == "signin":
-                uname = session.prompt(
-                    "Enter username for signin: ",
-                    validator=username_validator,
-                    is_password=False,
-                ).strip()
+                uname = prompt_username("Enter username for signin: ")
                 pword = session.prompt(
                     "Enter password for signin: ",
                     is_password=True,

--- a/netsec3.v3/chat_server.py
+++ b/netsec3.v3/chat_server.py
@@ -7,7 +7,6 @@ import os
 import time
 import base64
 import hmac
-import re
 from collections import defaultdict
 
 try:
@@ -92,17 +91,10 @@ def validate_timestamp_internal(timestamp_str):
         logging.warning(f"Malformed internal timestamp: {timestamp_str}")
 
 
-username_re = re.compile(r"^[A-Za-z][A-Za-z0-9_]{2,15}$")
-
-
 def validate_username_password_format(username, password):
-    """Validate signup username and password formats."""
-    if not isinstance(username, str) or not username_re.match(username):
-        return (
-            False,
-            "Username must start with a letter and contain only letters, numbers or '_' (3-16 chars)",
-        )
-    if not isinstance(password, str) or not (6 <= len(password) <= 128):
+    if not (3 <= len(username) <= 30 and username.isalnum()):
+        return False, "Username must be 3-30 alphanumeric chars."
+    if not (6 <= len(password) <= 128):
         return False, "Password must be 6-128 chars."
     return True, ""
 

--- a/netsec3.v3/chat_server.py
+++ b/netsec3.v3/chat_server.py
@@ -96,12 +96,13 @@ username_re = re.compile(r"^[A-Za-z][A-Za-z0-9_]{2,15}$")
 
 
 def validate_username_password_format(username, password):
-    if not username_re.match(username):
+    """Validate signup username and password formats."""
+    if not isinstance(username, str) or not username_re.match(username):
         return (
             False,
             "Username must start with a letter and contain only letters, numbers or '_' (3-16 chars)",
         )
-    if not (6 <= len(password) <= 128):
+    if not isinstance(password, str) or not (6 <= len(password) <= 128):
         return False, "Password must be 6-128 chars."
     return True, ""
 

--- a/netsec3.v3/chat_server.py
+++ b/netsec3.v3/chat_server.py
@@ -7,6 +7,7 @@ import os
 import time
 import base64
 import hmac
+import re
 from collections import defaultdict
 
 try:
@@ -91,9 +92,15 @@ def validate_timestamp_internal(timestamp_str):
         logging.warning(f"Malformed internal timestamp: {timestamp_str}")
 
 
+username_re = re.compile(r"^[A-Za-z][A-Za-z0-9_]{2,15}$")
+
+
 def validate_username_password_format(username, password):
-    if not (3 <= len(username) <= 30 and username.isalnum()):
-        return False, "Username must be 3-30 alphanumeric chars."
+    if not username_re.match(username):
+        return (
+            False,
+            "Username must start with a letter and contain only letters, numbers or '_' (3-16 chars)",
+        )
     if not (6 <= len(password) <= 128):
         return False, "Password must be 6-128 chars."
     return True, ""

--- a/netsec3.v3/chat_server.py
+++ b/netsec3.v3/chat_server.py
@@ -7,6 +7,7 @@ import os
 import time
 import base64
 import hmac
+import re
 from collections import defaultdict
 
 try:
@@ -31,6 +32,19 @@ user_credentials_cr = {}
 client_sessions = {}
 request_tracker = defaultdict(list)
 used_internal_nonces = {}
+
+# Regular expression for allowed usernames
+USERNAME_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9_]{2,15}$")
+
+
+def validate_username_format(username):
+    """Return True if the username matches the allowed format."""
+    return isinstance(username, str) and bool(USERNAME_PATTERN.fullmatch(username))
+
+
+def validate_password_format(password):
+    """Return True if the password meets length requirements."""
+    return isinstance(password, str) and 6 <= len(password) <= 128
 
 
 def load_cr_credentials():
@@ -92,9 +106,13 @@ def validate_timestamp_internal(timestamp_str):
 
 
 def validate_username_password_format(username, password):
-    if not (3 <= len(username) <= 30 and username.isalnum()):
-        return False, "Username must be 3-30 alphanumeric chars."
-    if not (6 <= len(password) <= 128):
+    """Validate both username and password formats."""
+    if not validate_username_format(username):
+        return False, (
+            "Username must start with a letter and contain only letters, "
+            "numbers or '_' (3-16 chars)"
+        )
+    if not validate_password_format(password):
         return False, "Password must be 6-128 chars."
     return True, ""
 


### PR DESCRIPTION
## Summary
- align `chat_server` username requirements with client
- import `re` in server for regex support

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68447713b1e083328cce354238cc053e