### PR TITLE
Add session management and signout support

### DIFF
--- a/netsec3/v3/chat_client.py
+++ b/netsec3/v3/chat_client.py
@@ -69,7 +69,7 @@ def prompt_username(message: str) -> str:
     return uname
 
 command_completer = WordCompleter(
-    ["signup", "signin", "signout", "message", "broadcast", "greet", "help", "logs", "exit"],
+    ["signup", "signin", "logout", "message", "broadcast", "greet", "help", "logs", "exit"],
     ignore_case=True,
 )
 
@@ -114,7 +114,7 @@ def print_command_list():
     console.print(
         "signup      Sign up with a new username and password\n"
         "signin      Log in with your credentials\n"
-        "signout     Logout from the server\n"
+        "logout      Logout from the server\n"
         "message     Send a private message: message <target> <content>\n"
         f"broadcast   Send a message to all users: broadcast <content>\n"
         "greet       Send a friendly greeting\n"
@@ -545,7 +545,7 @@ def client_main_loop(sock, server_address):
                     client_username = None
                 print_command_list()
 
-            elif action_cmd == "signout":
+            elif action_cmd == "logout":
                 if not is_authenticated:
                     console.print(
                         "<System> Error: not signed in.",
@@ -557,7 +557,7 @@ def client_main_loop(sock, server_address):
                     is_authenticated = False
                     client_username = None
                     console.print(
-                        "<System> Signed out.",
+                        "<System> Logged out.",
                         style="system",
                         markup=False,
                     )
@@ -638,7 +638,7 @@ def client_main_loop(sock, server_address):
                 console.print(
                     "signup      Sign up with a new username and password\n"
                     "signin      Log in with your credentials\n"
-                    "signout     Logout from the server\n"
+                    "logout      Logout from the server\n"
                     "message     Send a private message: message <target> <content>\n"
                     "broadcast   Send a message to all users: broadcast <content>\n"
                     "greet       Send a friendly greeting\n"

--- a/netsec3/v3/chat_client.py
+++ b/netsec3/v3/chat_client.py
@@ -69,7 +69,7 @@ def prompt_username(message: str) -> str:
     return uname
 
 command_completer = WordCompleter(
-    ["signup", "signin", "logout", "message", "broadcast", "greet", "help", "logs", "exit"],
+    ["signup", "signin", "logout", "users", "message", "broadcast", "greet", "help", "logs", "exit"],
     ignore_case=True,
 )
 
@@ -115,6 +115,7 @@ def print_command_list():
         "signup      Sign up with a new username and password\n"
         "signin      Log in with your credentials\n"
         "logout      Logout from the server\n"
+        "users       List online users\n"
         "message     Send a private message: message <target> <content>\n"
         f"broadcast   Send a message to all users: broadcast <content>\n"
         "greet       Send a friendly greeting\n"
@@ -304,6 +305,17 @@ def handle_encrypted_payload(payload):
             style="server",
             markup=False,
         )
+
+    elif msg_type == "USERS_LIST":
+        users = payload.get("users", [])
+        if users:
+            console.print(
+                "<Server> Online: " + ", ".join(users),
+                style="server",
+                markup=False,
+            )
+        else:
+            console.print("<Server> No users online.", style="server", markup=False)
 
     elif msg_type == "SIGNOUT_RESULT":
         if payload.get("success"):
@@ -562,6 +574,12 @@ def client_main_loop(sock, server_address):
                         markup=False,
                     )
                 print_command_list()
+            elif action_cmd == "users":
+                if not is_authenticated:
+                    console.print("<System> Error: not signed in.", style="error", markup=False)
+                else:
+                    send_secure_command_to_server(sock, server_address, "USERS", {"nonce": generate_nonce()})
+                print_command_list()
 
             elif action_cmd == "message":
                 if not is_authenticated:
@@ -639,6 +657,7 @@ def client_main_loop(sock, server_address):
                     "signup      Sign up with a new username and password\n"
                     "signin      Log in with your credentials\n"
                     "logout      Logout from the server\n"
+                    "users       List online users\n"
                     "message     Send a private message: message <target> <content>\n"
                     "broadcast   Send a message to all users: broadcast <content>\n"
                     "greet       Send a friendly greeting\n"

--- a/netsec3/v3/chat_client_secure.py
+++ b/netsec3/v3/chat_client_secure.py
@@ -799,6 +799,7 @@ def handle_signin(
     wait_start = time.time()
     while (
         auth_challenge_data is None
+        and not auth_successful_event.is_set()
         and time.time() - wait_start < config.auth_timeout
         and not stop_event.is_set()
     ):
@@ -845,6 +846,9 @@ def handle_signin(
                 exc_info=True,
             )
             client_username = None
+    elif auth_successful_event.is_set():
+        client_username = None
+        return
     else:
         console.print(
             "<Server> Signin failed: challenge timeout",

--- a/netsec3/v3/chat_client_secure.py
+++ b/netsec3/v3/chat_client_secure.py
@@ -556,10 +556,18 @@ def handle_encrypted_payload(payload: dict) -> None:
             console.print(f"[{ts_fmt}] <Bcast {sender}> {content}", style="server")
 
     elif msg_type == "MESSAGE_STATUS":
+        status = payload.get("status")
         console.print(
-            f"<Server> {payload.get('status')}: {msg_detail}",
+            f"<Server> {status}: {msg_detail}",
             style="server",
         )
+        if status == "MESSAGE_FAIL":
+            m = re.search(r"User '([^']+)'", msg_detail or "")
+            if m:
+                entry = session_keys.get(m.group(1))
+                if entry:
+                    entry.clear()
+                    entry["state"] = "fail"
 
     elif msg_type == "SIGNOUT_RESULT":
         if payload.get("success"):

--- a/netsec3/v3/chat_server.py
+++ b/netsec3/v3/chat_server.py
@@ -252,6 +252,7 @@ def server(port):
                         break
                 if not (target_addr and target_sk):
                     logging.info("NS_REQ for offline user %s from %s", peer, client_addr)
+                    sock.sendto(f"NS_FAIL:{peer}:offline".encode("utf-8"), client_addr)
                     continue
                 session_key = os.urandom(crypto_utils.AES_KEY_SIZE)
                 ticket_bytes = crypto_utils.serialize_payload({

--- a/netsec3/v3/chat_server.py
+++ b/netsec3/v3/chat_server.py
@@ -427,8 +427,12 @@ def server(port):
                 else:
                     target_addr, target_sk = None, None
                     for addr, s_data in client_sessions.items():  # Find recipient
-                        if s_data.get("username") == to_user:
+                        if (
+                            s_data.get("username") == to_user
+                            and active_usernames.get(to_user) == addr
+                        ):
                             target_addr, target_sk = addr, s_data.get("channel_sk")
+                            break
                     if target_addr and target_sk:
                         send_encrypted_response(sock, target_addr, target_sk,
                                                 {"type": "SECURE_MESSAGE_INCOMING", "from_user": sender,

--- a/netsec3/v3/chat_server.py
+++ b/netsec3/v3/chat_server.py
@@ -387,6 +387,22 @@ def server(port):
                                         {"type": "GREETING_RESPONSE", "status": "GREETING_OK",
                                          "detail": f"Hello {session['username']}! Greeting received."})
 
+            elif command_header == "USERS":
+                logging.info(
+                    f"Processing USERS request from '{session['username']}'@{client_addr}"
+                )
+                online_list = list(active_usernames.keys())
+                send_encrypted_response(
+                    sock,
+                    client_addr,
+                    current_channel_sk,
+                    {
+                        "type": "USERS_LIST",
+                        "users": online_list,
+                        "detail": f"{len(online_list)} online",
+                    },
+                )
+
             elif command_header == "SIGNOUT":
                 username = session.get("username")
                 if username and active_usernames.get(username) == client_addr:

--- a/netsec3/v3/test_protocol.py
+++ b/netsec3/v3/test_protocol.py
@@ -42,6 +42,26 @@ def recv_payload(sock, sk):
     decrypted = crypto_utils.decrypt_aes_gcm(sk, data.decode())
     return crypto_utils.deserialize_payload(decrypted)
 
+def sign_up(sock, sk, username, password):
+    send_command(sock, sk, "SECURE_SIGNUP", {"username": username, "password": password})
+    return recv_payload(sock, sk)
+
+def sign_in(sock, sk, username, password):
+    send_command(sock, sk, "AUTH_REQUEST", {"username": username})
+    chal = recv_payload(sock, sk)
+    if chal.get("type") != "AUTH_CHALLENGE":
+        return chal
+    salt = bytes.fromhex(chal["salt"])
+    key = crypto_utils.derive_password_verifier(password, salt)
+    proof = crypto_utils.compute_hmac_sha256(key, chal["challenge"])
+    proof_b64 = base64.b64encode(proof).decode()
+    send_command(sock, sk, "AUTH_RESPONSE", {"challenge_response": proof_b64, "client_nonce": str(uuid.uuid4())})
+    return recv_payload(sock, sk)
+
+def sign_out(sock, sk):
+    send_command(sock, sk, "SIGNOUT", {"nonce": str(uuid.uuid4())})
+    return recv_payload(sock, sk)
+
 
 def sign_up_and_sign_in(sock, sk, username, password):
     send_command(sock, sk, "SECURE_SIGNUP", {"username": username, "password": password})
@@ -158,6 +178,29 @@ class ChatProtocolTest(unittest.TestCase):
         )
         ack = recv_payload(self.sock1, self.sk1)
         self.assertEqual(ack.get("status"), "BROADCAST_FAIL")
+
+    def test_duplicate_login_and_signout(self):
+        sign_up(self.sock1, self.sk1, "dupuser", "pw12345")
+        resp1 = sign_in(self.sock1, self.sk1, "dupuser", "pw12345")
+        self.assertTrue(resp1.get("success"))
+        resp2 = sign_in(self.sock2, self.sk2, "dupuser", "pw12345")
+        self.assertFalse(resp2.get("success"))
+        sign_out(self.sock1, self.sk1)
+        resp3 = sign_in(self.sock2, self.sk2, "dupuser", "pw12345")
+        self.assertTrue(resp3.get("success"))
+
+    def test_message_to_offline_user(self):
+        sign_up(self.sock1, self.sk1, "alice", "pw12345")
+        sign_up(self.sock2, self.sk2, "bob", "pw23456")
+        sign_in(self.sock1, self.sk1, "alice", "pw12345")
+        send_command(
+            self.sock1,
+            self.sk1,
+            "SECURE_MESSAGE",
+            {"to_user": "bob", "content": "hi", "timestamp": str(time.time())},
+        )
+        ack = recv_payload(self.sock1, self.sk1)
+        self.assertEqual(ack.get("status"), "MESSAGE_FAIL")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- enforce single active session per username in `chat_server`
- add `SIGNOUT` command to server and client
- update client command list and handlers for signout
- track active usernames and clean them on disconnect
- extend protocol tests for duplicate login and offline messaging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845b24c03b88332b2a478e8c0128775