### PR TITLE
Add README and fix gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,4 +191,5 @@ cython_debug/
 #  exclude from AI features like autocomplete and code analysis. Recommended for sensitive data
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
-.cursorindexingignoreuser_credentials_ecdh_cr.json
+.cursorindexingignore
+user_credentials_ecdh_cr.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# NetSec3 Secure Chat
+
+This project provides a simple secure chat application demonstrating:
+
+- Elliptic Curve Diffie-Hellman key exchange
+- Challenge‑response user authentication
+- AES‑GCM encrypted messaging
+
+## Setup
+
+Install the required packages:
+
+```bash
+pip install -r requirements.txt
+```
+
+Run the test suite to verify everything works:
+
+```bash
+pytest -q
+```
+
+## Usage
+
+### Start the server
+
+```bash
+python -m netsec3.v3.chat_server <port>
+```
+
+Choose any free port between `1025` and `65535`.
+
+### Run the client
+
+```bash
+python -m netsec3.v3.chat_client_secure <host> <port>
+```
+
+Use the same `<port>` used when starting the server and replace `<host>` with the server's IP address.


### PR DESCRIPTION
## Summary
- add project overview and usage details in a README
- split `.cursorindexingignoreuser_credentials_ecdh_cr.json` into separate rules in `.gitignore`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846a34766388332b093587970511336