### PR TITLE
Improve server logging and nonce pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ python -m netsec3.v3.chat_server <port>
 
 Choose any free port between `1025` and `65535`.
 
+Server activity is recorded in `server.log` located in the
+same directory as the server script.
+
 ### Run the client
 
 ```bash

--- a/netsec3/v3/chat_server.py
+++ b/netsec3/v3/chat_server.py
@@ -349,6 +349,8 @@ def server(port, stop_event=None):
                                          "detail": "Signed out."})
                 if username:
                     server_utils.notify_user_logout(sock, username, client_sessions)
+                # Remove the session key after logout so the client must re-handshake
+                client_sessions.pop(client_addr, None)
 
             elif command_header == "SECURE_MESSAGE":
                 to_user = req_payload.get("to_user")

--- a/netsec3/v3/chat_server.py
+++ b/netsec3/v3/chat_server.py
@@ -25,14 +25,11 @@ except ImportError:
         print("Error: crypto_utils.py not found.")
         sys.exit(1)
 
-# Configure logging: INFO level for server operations
+# Configure logging: INFO level to file only
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - SERVER - %(levelname)s - %(message)s",
-    handlers=[
-        logging.FileHandler("server.log", mode="a"),
-        logging.StreamHandler(),
-    ],
+    handlers=[logging.FileHandler("server.log", mode="a")],
 )
 
 CREDENTIALS_FILE = config.CREDENTIALS_FILE

--- a/netsec3/v3/chat_server.py
+++ b/netsec3/v3/chat_server.py
@@ -451,7 +451,7 @@ def server(port, stop_event=None):
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:
-        print("Usage: python chat_server.py <port>")
+        print("Usage: python -m netsec3.v3.chat_server <port>")
         sys.exit(1)
     try:
         server_port = int(sys.argv[1])

--- a/netsec3/v3/test_nonce_utils.py
+++ b/netsec3/v3/test_nonce_utils.py
@@ -1,0 +1,15 @@
+import time
+from . import server_utils, config
+
+
+def test_validate_internal_nonce_pruning():
+    server_utils.reset_caches()
+    old_nonce = "old"
+    # Insert an expired nonce manually
+    server_utils.used_internal_nonces[old_nonce] = time.time() - (config.INTERNAL_NONCE_EXPIRY_SECONDS + 1)
+    new_nonce = "new"
+    assert server_utils.validate_internal_nonce(new_nonce)
+    # Old nonce should be pruned
+    assert old_nonce not in server_utils.used_internal_nonces
+    # Reusing new nonce before expiry should fail
+    assert not server_utils.validate_internal_nonce(new_nonce)


### PR DESCRIPTION
## Summary
- add file logger and log every request and response
- fix outdated filename references
- use active user mapping for message routing
- prune expired internal nonces
- test nonce pruning behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68471d8a79bc8332bbc735b2e72dc280